### PR TITLE
Missing datatype bugfix

### DIFF
--- a/kif_lib/store/sparql.py
+++ b/kif_lib/store/sparql.py
@@ -1182,7 +1182,10 @@ At line {line}, column {column}:
             else:
                 raise self._should_not_get_here()
             if get_datatype and 'datatype' in entry:
-                datatype: Optional[Datatype] = entry.check_datatype('datatype')
+                try:
+                    datatype: Optional[Datatype] = entry.check_datatype('datatype')
+                except ValueError:
+                    datatype = None
             else:
                 datatype = None
             if get_label and 'label' in entry:

--- a/kif_lib/store/sparql.py
+++ b/kif_lib/store/sparql.py
@@ -1182,10 +1182,11 @@ At line {line}, column {column}:
             else:
                 raise self._should_not_get_here()
             if get_datatype and 'datatype' in entry:
+                datatype: Optional[Datatype] = None
                 try:
-                    datatype: Optional[Datatype] = entry.check_datatype('datatype')
-                except ValueError:
-                    datatype = None
+                    entry.check_datatype('datatype')
+                except Store.Error as e:
+                    LOG.warning(e)
             else:
                 datatype = None
             if get_label and 'label' in entry:

--- a/kif_lib/store/sparql.py
+++ b/kif_lib/store/sparql.py
@@ -1184,7 +1184,7 @@ At line {line}, column {column}:
             if get_datatype and 'datatype' in entry:
                 datatype: Optional[Datatype] = None
                 try:
-                    entry.check_datatype('datatype')
+                    datatype = entry.check_datatype('datatype')
                 except Store.Error as e:
                     LOG.warning(e)
             else:


### PR DESCRIPTION
Tentative bugfix for the error raised when running the following snippet
```python
#import logging
#logging.basicConfig(level=logging.DEBUG)

from kif_lib import *
from kif_lib.vocabulary import wd
import datetime

store = Store("sparql", "https://query.wikidata.org/sparql")

store.extra_references = [
    ReferenceRecord(
        wd.stated_in(wd.Wikidata),
        wd.reference_URL(store.iri),
        wd.retrieved(Time(datetime.datetime.now())))]

items = [Property(IRI('http://www.wikidata.org/entity/P8224'))]

for i, (entity, desc) in enumerate(dict(store.get_descriptor(list(items), 'en')).items(), 1):
    if not desc:
        continue
    label = ""
    description = ""
    if desc.label:
        label = desc.label.value
    if desc.description:
        description = desc.description.value
    print(label, description)
 ```